### PR TITLE
fixup: Fix a few minor cppcheck warnings

### DIFF
--- a/components/panics/src/memfault_fault_handling_arm.c
+++ b/components/panics/src/memfault_fault_handling_arm.c
@@ -169,7 +169,7 @@ void memfault_fault_handling_assert(void *pc, void *lr, uint32_t extra) {
   //   At that priority level, we can't get interrupted
   //   We can leverage the arm architecture to auto-capture register state for us
   //   If the user is using psp/msp, we start execution from a more predictable stack location
-  const uint32_t nmipendset_mask = 0x1 << 31;
+  const uint32_t nmipendset_mask = 0x1u << 31;
   volatile uint32_t *icsr = (uint32_t *)0xE000ED04;
   *icsr |= nmipendset_mask;
   __asm("isb");

--- a/platforms/wiced/libraries/memfault/platform_reference_impl/memfault_platform_http_client.c
+++ b/platforms/wiced/libraries/memfault/platform_reference_impl/memfault_platform_http_client.c
@@ -182,7 +182,7 @@ static wiced_result_t prv_connect_and_send_coredump_request(
                                    security, MEMFAULT_HTTP_CONNECT_TIMEOUT_MS));
 
   char content_length[12] = {0};
-  snprintf(content_length, sizeof(content_length), "%d", cd_info->total_size);
+  snprintf(content_length, sizeof(content_length), "%zu", cd_info->total_size);
 
   const http_header_field_t headers[] = {
       [0] = {


### PR DESCRIPTION
Two warnings thrown out by cppcheck:

```plaintext
[platforms/wiced/libraries/memfault/platform_reference_impl/memfault_platform_http_client.c:185]: (portability) %d in format string (no. 1) requires 'int' but the argument type is 'size_t {aka unsigned lon
g}'.
[components/panics/src/memfault_fault_handling_arm.c:172]: (error) Shifting signed 32-bit value by 31 bits is undefined behaviour
```

Fix them! Cppcheck was run in default mode:

```bash
cppcheck --error-exitcode=1 $(find . -name '*.c' -type f)

 # extra checkers can be enabled with
cppcheck --error-exitcode=1 --enable=all $(find . -name '*.c' -type f)
```