### PR TITLE
Check return value of `memfault_circular_bufffer_write_at_offset`.

### DIFF
--- a/tests/src/test_memfault_circular_buffer.cpp
+++ b/tests/src/test_memfault_circular_buffer.cpp
@@ -58,7 +58,7 @@ TEST(MfltCircularBufferTestGroup, Test_MfltCircularWriteAtOffsetBasic) {
 
   // overwrite first two bytes and fill rest of buffer
   const uint8_t seq2[] = { 0x3, 0x4, 0x5, 0x6 };
-  memfault_circular_buffer_write_at_offset(&buffer, 2, seq2, sizeof(seq2));
+  success = memfault_circular_buffer_write_at_offset(&buffer, 2, seq2, sizeof(seq2));
   CHECK(success);
 
   // buffer should be full


### PR DESCRIPTION
Actually store the return value of `memfault_circular_bufffer_write_at_offset`.