### PR TITLE
Fix bug in memfault_log_save_preformatted

### DIFF
--- a/components/core/src/memfault_log.c
+++ b/components/core/src/memfault_log.c
@@ -328,7 +328,7 @@ void memfault_log_save_preformatted(eMemfaultPlatformLogLevel level,
           .hdr = prv_build_header(level, kMemfaultLogRecordType_Preformatted),
         };
         memfault_circular_buffer_write(circ_bufp, &entry, sizeof(entry));
-        memfault_circular_buffer_write(circ_bufp, log, log_len);
+        memfault_circular_buffer_write(circ_bufp, log, entry.len);
         log_written = true;
     }
   }


### PR DESCRIPTION
If log_len is > MEMFAULT_LOG_MAX_LINE_SAVE_LEN, the entry len will be
MEMFAULT_MIN(log_len, MEMFAULT_LOG_MAX_LINE_SAVE_LEN) but the write to
circ_bufp is still log_len, which corrupts the data