### PR TITLE
ports: zephyr: remove non-existing Kconfig option

### DIFF
--- a/ports/zephyr/Kconfig
+++ b/ports/zephyr/Kconfig
@@ -5,7 +5,6 @@ config MEMFAULT
         select RUNTIME_NMI
         select EXTRA_EXCEPTION_INFO
         select DEBUG_THREAD_INFO
-        select OPENOCD_SUPPORT
         help
           Enable Zephyr Integration with the Memfault SDK
           At the moment a port is only provided for Cortex-M based targets


### PR DESCRIPTION
OPENOCD_SUPPORT was deprecated in favor of DEBUG_THREAD_INFO in Zephyr
v2.6. OPENOCD_SUPPORT is no longer part of Zephyr, so remove it. Note
that DEBUG_THREAD_INFO was already selected.