### PR TITLE
ports: zephyr: support release based Kconfig versions

### DIFF
--- a/ports/zephyr/Kconfig
+++ b/ports/zephyr/Kconfig
@@ -4,8 +4,6 @@ config MEMFAULT
         depends on CPU_CORTEX_M
         select RUNTIME_NMI
         select EXTRA_EXCEPTION_INFO
-        select DEBUG_THREAD_INFO
-        select OPENOCD_SUPPORT
         help
           Enable Zephyr Integration with the Memfault SDK
           At the moment a port is only provided for Cortex-M based targets

--- a/ports/zephyr/Kconfig.2_5_0
+++ b/ports/zephyr/Kconfig.2_5_0
@@ -1,0 +1,4 @@
+config MEMFAULT
+        select OPENOCD_SUPPORT
+
+rsource "Kconfig"

--- a/ports/zephyr/Kconfig.2_6_0
+++ b/ports/zephyr/Kconfig.2_6_0
@@ -1,0 +1,4 @@
+config MEMFAULT
+        select DEBUG_THREAD_INFO
+
+rsource "Kconfig"

--- a/ports/zephyr/modules/modules.cmake
+++ b/ports/zephyr/modules/modules.cmake
@@ -1,0 +1,8 @@
+if(PROJECT_VERSION VERSION_LESS 2.6.0)
+  set(ZEPHYR_MEMFAULT_FIRMWARE_SDK_KCONFIG ${CMAKE_CURRENT_LIST_DIR}/../Kconfig.2_5_0)
+else()
+  # When a newer Zephyr with incompatible Kconfig tree is released then update
+  # the `else()` to `elseif(PROJECT_VERSION VERSION_LESS <incompatible-version>)`
+  # and then add a new Kconfig.<version> file to accomodate changes in the new Zephyr.
+  set(ZEPHYR_MEMFAULT_FIRMWARE_SDK_KCONFIG ${CMAKE_CURRENT_LIST_DIR}/../Kconfig.2_6_0)
+endif()

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,3 +1,5 @@
 build:
   cmake: ports/zephyr
-  kconfig: ports/zephyr/Kconfig
+  kconfig-ext: True
+  settings:
+    module_ext_root: ports/zephyr


### PR DESCRIPTION
This PR showcase how the Kconfig tree and symbols used / referred in this tree can be adjusted based on the current Zephyr release.

It uses the MODULE_EXT_ROOT feature by setting `kconfig-ext: True` and specifying memfault as an external root of it's own.
https://docs.zephyrproject.org/latest/guides/modules.html#module-integration-files-external

However, this feature was introduced with Zephyr v2.5.0, and therefore will not work with older Zephyr releases.
Older Zephyr releases will fail on the yaml parsing of `module.yml`.

So if older Zephyr are still supported, then an option is to have a dedicated branch for those where the only difference to the master branch is the `zephyr/module.yml` file in old format.


------------

This commit introduces Zephyr release adjusted Kconfig files.

This allows memfault-firmware-sdk to adjust Kconfig symbols and selects
or depends according to the Kconfig symbols available in Zephyr.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>