### PR TITLE
feat: Select LOG_OUTPUT when MEMFAULT_LOGGING_ENABLE is y-selected

### DIFF
--- a/ports/zephyr/Kconfig
+++ b/ports/zephyr/Kconfig
@@ -113,6 +113,7 @@ config MEMFAULT_LOGGING_ENABLE
         bool "MEMFAULT Zephyr backend logging Enable [EXPERIMENTAL]"
         default n
         select LOG
+        select LOG_OUTPUT
         help
           Adds support for routing Zephyr logging calls to the Memfault
           logging backend.


### PR DESCRIPTION
This fixes the linker error about undefined references to log_output_*
functions if logging (CONFIG_LOG) is disabled.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>