### PR TITLE
Use Zephyr 3.2.x full paths for includes

### DIFF
--- a/ports/zephyr/Kconfig
+++ b/ports/zephyr/Kconfig
@@ -5,7 +5,6 @@ config MEMFAULT
         select RUNTIME_NMI
         select EXTRA_EXCEPTION_INFO
         select DEBUG_THREAD_INFO
-        select LEGACY_INCLUDE_PATH
         help
           Enable Zephyr Integration with the Memfault SDK
           At the moment a port is only provided for Cortex-M based targets

--- a/ports/zephyr/common/memfault_http_periodic_upload.c
+++ b/ports/zephyr/common/memfault_http_periodic_upload.c
@@ -8,10 +8,16 @@
 #include "memfault/core/data_packetizer.h"
 #include "memfault/core/debug_log.h"
 
-#include <init.h>
-#include <kernel.h>
+#if CONFIG_LEGACY_INCLUDE_PATH
+  #include <init.h>
+  #include <kernel.h>
+  #include <zephyr.h>
+#else
+  #include <zephyr/init.h>
+  #include <zephyr/kernel.h>  
+#endif
+
 #include <random/rand32.h>
-#include <zephyr.h>
 
 #if CONFIG_MEMFAULT_HTTP_PERIODIC_UPLOAD_USE_DEDICATED_WORKQUEUE
 static K_THREAD_STACK_DEFINE(

--- a/ports/zephyr/common/memfault_platform_core.c
+++ b/ports/zephyr/common/memfault_platform_core.c
@@ -5,7 +5,14 @@
 
 #include "memfault/core/platform/core.h"
 
-#include <init.h>
+
+#if CONFIG_LEGACY_INCLUDE_PATH
+  #include <init.h>
+#else
+  #include <zephyr/init.h>
+  #include <zephyr/kernel.h>  
+#endif
+
 #include <soc.h>
 
 #include "memfault/components.h"

--- a/ports/zephyr/common/memfault_platform_coredump_regions.c
+++ b/ports/zephyr/common/memfault_platform_coredump_regions.c
@@ -10,9 +10,13 @@
 #include "memfault/panics/platform/coredump.h"
 #include "memfault/panics/arch/arm/cortex_m.h"
 
-#include <zephyr.h>
-#include <kernel.h>
-#include <kernel_structs.h>
+#if CONFIG_LEGACY_INCLUDE_PATH
+    #include <zephyr.h>
+    #include <kernel.h>
+    #include <kernel_structs.h>
+#else
+    #include <zephyr/kernel.h>  
+#endif
 
 #include "memfault/ports/zephyr/version.h"
 

--- a/ports/zephyr/common/memfault_platform_http.c
+++ b/ports/zephyr/common/memfault_platform_http.c
@@ -12,12 +12,17 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <init.h>
-#include <kernel.h>
+#if CONFIG_LEGACY_INCLUDE_PATH
+  #include <init.h>
+  #include <kernel.h>
+  #include <zephyr.h>
+#else
+  #include <zephyr/init.h>
+  #include <zephyr/kernel.h>  
+#endif
 
 #include <net/socket.h>
 #include <net/tls_credentials.h>
-#include <zephyr.h>
 
 #include "memfault/core/compiler.h"
 #include "memfault/core/data_packetizer.h"

--- a/ports/zephyr/common/memfault_platform_lock.c
+++ b/ports/zephyr/common/memfault_platform_lock.c
@@ -7,7 +7,12 @@
 
 #include "memfault/core/platform/core.h"
 
-#include <init.h>
+#if CONFIG_LEGACY_INCLUDE_PATH
+  #include <init.h>
+#else
+  #include <zephyr/init.h>
+  #include <zephyr/kernel.h>
+#endif
 
 K_MUTEX_DEFINE(s_memfault_mutex);
 

--- a/ports/zephyr/common/memfault_platform_metrics.c
+++ b/ports/zephyr/common/memfault_platform_metrics.c
@@ -3,7 +3,11 @@
 //! Copyright (c) Memfault, Inc.
 //! See License.txt for details
 
-#include <zephyr.h>
+#if CONFIG_LEGACY_INCLUDE_PATH
+  #include <zephyr.h>
+#else
+  #include <zephyr/kernel.h>
+#endif
 
 #include <stdbool.h>
 

--- a/ports/zephyr/common/memfault_software_watchdog.c
+++ b/ports/zephyr/common/memfault_software_watchdog.c
@@ -11,7 +11,11 @@
 #include "memfault/panics/assert.h"
 #include "memfault/ports/watchdog.h"
 
-#include <zephyr.h>
+#if CONFIG_LEGACY_INCLUDE_PATH
+  #include <zephyr.h>
+#else
+  #include <zephyr/kernel.h>
+#endif
 
 static void prv_software_watchdog_timeout(struct k_timer *dummy) {
   MEMFAULT_SOFTWARE_WATCHDOG();

--- a/ports/zephyr/common/memfault_zephyr_ram_regions.c
+++ b/ports/zephyr/common/memfault_zephyr_ram_regions.c
@@ -8,9 +8,15 @@
 
 #include "memfault/ports/zephyr/coredump.h"
 
-#include <zephyr.h>
-#include <kernel.h>
-#include <kernel_structs.h>
+#if CONFIG_LEGACY_INCLUDE_PATH
+  #include <zephyr.h>
+  #include <kernel.h>
+  #include <kernel_structs.h>
+#else
+  #include <zephyr/kernel.h>
+  #include <zephyr/kernel_structs.h>
+#endif
+
 #include <version.h>
 
 #include "memfault/components.h"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ invoke==1.2.0
 mbed-cli==1.10.1
 pyftdi==0.29.4
 west==0.13.0
-pyyaml==5.3
+pyyaml==5.4
 colorama==0.4.3
 fastcov==1.14


### PR DESCRIPTION
 LEGACY_INCLUDE_PATH has already been deprecated in Zephyr 3.2.0.
 
 In order to get Memfault to build, full Zephyr paths are now needed.
 
CONFIG_LEGACY_INCLUDE_PATH could still be set (prf.conf) for older versions, but shouldn't be needed. The CONFIG_LEGACY_INCLUDE_PATH if statements will need removing after a few more revisions, or could just be ignored already.