### PR TITLE
Update includes to support recent Zephyr change

### DIFF
--- a/ports/zephyr/common/memfault_platform_core.c
+++ b/ports/zephyr/common/memfault_platform_core.c
@@ -6,6 +6,7 @@
 #include "memfault/core/platform/core.h"
 
 #include <init.h>
+#include <kernel.h>
 #include <soc.h>
 
 #include "memfault/components.h"

--- a/ports/zephyr/common/memfault_platform_lock.c
+++ b/ports/zephyr/common/memfault_platform_lock.c
@@ -7,7 +7,7 @@
 
 #include "memfault/core/platform/core.h"
 
-#include <init.h>
+#include <kernel.h>
 
 K_MUTEX_DEFINE(s_memfault_mutex);
 


### PR DESCRIPTION
A recent Zephyr change removed the `<zephyr/kernel.h>` header from the
`<zephyr/init.h>` header:

https://github.com/zephyrproject-rtos/zephyr/commit/a6a4400b8621bc618c60561c5bdd90b2e8ce09e0

Update the SDK includes to support this change.

See also #35, which was the origin of this change (thanks to @percz and
@desowin for taking the time to make and test the patch!)