### PR TITLE
Port to Nuttx

### DIFF
--- a/ports/nuttx/config/memfault_metrics_heartbeat_config.def
+++ b/ports/nuttx/config/memfault_metrics_heartbeat_config.def
@@ -1,0 +1,4 @@
+//! Define custom system metrics to track. For example,
+// MEMFAULT_METRICS_KEY_DEFINE(main_task_stack_hwm, kMemfaultMetricType_Unsigned)
+// MEMFAULT_METRICS_KEY_DEFINE(ble_min_rssi, kMemfaultMetricType_Signed)
+// MEMFAULT_METRICS_KEY_DEFINE(mcu_sleep_time_ms, kMemfaultMetricType_Timer)

--- a/ports/nuttx/config/memfault_trace_reason_user_config.def
+++ b/ports/nuttx/config/memfault_trace_reason_user_config.def
@@ -1,0 +1,3 @@
+//! Define custom error reasons that can be filtered & searched
+//! on in the Memfault UI, i.e
+// MEMFAULT_TRACE_REASON_DEFINE(critical_error)

--- a/ports/nuttx/include/memfault_platform_config.h
+++ b/ports/nuttx/include/memfault_platform_config.h
@@ -1,0 +1,62 @@
+#pragma once
+
+//! @file memfault_platform_config.h
+//!
+//! Copyright 2022 Memfault, Inc
+//!
+//! Licensed under the Apache License, Version 2.0 (the "License");
+//! you may not use this file except in compliance with the License.
+//! You may obtain a copy of the License at
+//!
+//!     http://www.apache.org/licenses/LICENSE-2.0
+//!
+//! Unless required by applicable law or agreed to in writing, software
+//! distributed under the License is distributed on an "AS IS" BASIS,
+//! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//! See the License for the specific language governing permissions and
+//! limitations under the License.
+//!
+//! @brief
+//! Platform overrides for the default configuration settings in the memfault-firmware-sdk.
+//! Default configuration settings can be found in "memfault/config.h"
+
+/*****************************************************************************
+ * Included Files
+ *****************************************************************************/
+
+/****************************************************************************
+ * Preprocessor Definitions
+ ****************************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// For example, decide if you want to use the Gnu Build ID.
+// #define MEMFAULT_USE_GNU_BUILD_ID 1
+
+#define MEMFAULT_PLATFORM_HAS_LOG_CONFIG 1
+
+#ifdef __cplusplus
+}
+#endif
+
+/****************************************************************************
+ * Preprocessor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/

--- a/ports/nuttx/include/memfault_platform_log_config.h
+++ b/ports/nuttx/include/memfault_platform_log_config.h
@@ -1,0 +1,63 @@
+//! @file
+//!
+//! Copyright 2022 Memfault, Inc
+//!
+//! Licensed under the Apache License, Version 2.0 (the "License");
+//! you may not use this file except in compliance with the License.
+//! You may obtain a copy of the License at
+//!
+//!     http://www.apache.org/licenses/LICENSE-2.0
+//!
+//! Unless required by applicable law or agreed to in writing, software
+//! distributed under the License is distributed on an "AS IS" BASIS,
+//! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//! See the License for the specific language governing permissions and
+//! limitations under the License.
+//!
+//! @brief
+//! Logging depends on how your configuration does logging. See
+//! https://docs.memfault.com/docs/mcu/self-serve/#logging-dependency
+
+
+/*****************************************************************************
+ * Included Files
+ *****************************************************************************/
+
+#include <syslog.h>
+
+/****************************************************************************
+ * Preprocessor Definitions
+ ****************************************************************************/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MEMFAULT_LOG_DEBUG(fmt, ...) syslog(LOG_DEBUG, "%s: " fmt "\n", __FUNCTION__, ##__VA_ARGS__)
+#define MEMFAULT_LOG_INFO(fmt, ...)  syslog(LOG_INFO, "%s: " fmt "\n", __FUNCTION__, ##__VA_ARGS__)
+#define MEMFAULT_LOG_WARN(fmt, ...)  syslog(LOG_WARNING, "%s: " fmt "\n", __FUNCTION__, ##__VA_ARGS__)
+#define MEMFAULT_LOG_ERROR(fmt, ...) syslog(LOG_ERR, "%s: " fmt "\n", __FUNCTION__, ##__VA_ARGS__)
+
+#ifdef __cplusplus
+}
+#endif
+
+/****************************************************************************
+ * Preprocessor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/

--- a/ports/nuttx/src/memfault_platform_boot.c
+++ b/ports/nuttx/src/memfault_platform_boot.c
@@ -1,0 +1,93 @@
+//! @file memfault_platform_boot.c
+//!
+//! Copyright 2022 Memfault, Inc
+//!
+//! Licensed under the Apache License, Version 2.0 (the "License");
+//! you may not use this file except in compliance with the License.
+//! You may obtain a copy of the License at
+//!
+//!     http://www.apache.org/licenses/LICENSE-2.0
+//!
+//! Unless required by applicable law or agreed to in writing, software
+//! distributed under the License is distributed on an "AS IS" BASIS,
+//! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//! See the License for the specific language governing permissions and
+//! limitations under the License.
+//!
+//! Glue layer between the Memfault SDK and the Nuttx platform
+
+/*****************************************************************************
+ * Included Files
+ *****************************************************************************/
+
+#include "memfault/components.h"
+#include "memfault/ports/reboot_reason.h"
+
+#include <sys/time.h>
+#include <stdbool.h>
+#include <signal.h>
+#include <sched.h>
+#include <time.h>
+#include <pthread.h>
+#include <errno.h>
+
+#include <nuttx/clock.h>
+
+/****************************************************************************
+ * Preprocessor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: memfault_platform_boot
+ ****************************************************************************/
+
+/**
+ * @brief Main memfault platform function. Should be called as soon as 
+ * posible at OS initialization phase.
+ * 
+ * @return int 
+ */
+
+int memfault_platform_boot(void) {
+
+  memfault_build_info_dump();
+  memfault_device_info_dump();
+  memfault_platform_reboot_tracking_boot();
+
+  // initialize the event storage buffer
+  static uint8_t s_event_storage[1024];
+  const sMemfaultEventStorageImpl *evt_storage =
+    memfault_events_storage_boot(s_event_storage, sizeof(s_event_storage));
+
+  // configure trace events to store into the buffer
+  memfault_trace_event_boot(evt_storage);
+
+  // record the current reboot reason
+  memfault_reboot_tracking_collect_reset_info(evt_storage);
+
+  // configure the metrics component to store into the buffer
+  sMemfaultMetricBootInfo boot_info = {
+    .unexpected_reboot_count = memfault_reboot_tracking_get_crash_count(),
+  };
+  memfault_metrics_boot(evt_storage, &boot_info);
+
+  MEMFAULT_LOG_INFO("Memfault Initialized!");
+
+  return 0;
+}

--- a/ports/nuttx/src/memfault_platform_info.c
+++ b/ports/nuttx/src/memfault_platform_info.c
@@ -1,0 +1,132 @@
+//! @file memfault_platform_info.c
+//!
+//! Copyright 2022 Memfault, Inc
+//!
+//! Licensed under the Apache License, Version 2.0 (the "License");
+//! you may not use this file except in compliance with the License.
+//! You may obtain a copy of the License at
+//!
+//!     http://www.apache.org/licenses/LICENSE-2.0
+//!
+//! Unless required by applicable law or agreed to in writing, software
+//! distributed under the License is distributed on an "AS IS" BASIS,
+//! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//! See the License for the specific language governing permissions and
+//! limitations under the License.
+//!
+//! Glue layer between the Memfault SDK and the Nuttx platform
+
+/*****************************************************************************
+ * Included Files
+ *****************************************************************************/
+
+#include "memfault/components.h"
+#include "memfault/ports/reboot_reason.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/boardctl.h>
+
+/****************************************************************************
+ * Preprocessor Definitions
+ ****************************************************************************/
+
+#ifndef CONFIG_MEMFAULT_DEVICE_SERIAL
+#define CONFIG_MEMFAULT_DEVICE_SERIAL      "DEMOSERIAL" 
+#endif
+
+#ifndef CONFIG_MEMFAULT_HARDWARE_VERSION
+#define CONFIG_MEMFAULT_HARDWARE_VERSION   "app-fw"
+#endif
+
+#ifndef CONFIG_MEMFAULT_SOFTWARE_TYPE
+#define CONFIG_MEMFAULT_SOFTWARE_TYPE      "1.0.0"
+#endif
+
+#ifndef CONFIG_MEMFAULT_SOFTWARE_VERSION
+#define CONFIG_MEMFAULT_SOFTWARE_VERSION   "dvt1"
+#endif
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: prv_int_to_ascii_hex
+ ****************************************************************************/
+
+/**
+ * @brief Convert integers into ascii hex
+ * 
+ * @param val 
+ * @return char 
+ */
+
+static char prv_int_to_ascii_hex(uint8_t val) {
+  return val < 10 ? (char)val + '0' : (char)(val - 10) + 'A';
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: memfault_platform_get_device_info
+ ****************************************************************************/
+
+/**
+ * @brief Get device info form Nuttx platform
+ * 
+ * @param info 
+ */
+
+void memfault_platform_get_device_info(sMemfaultDeviceInfo *info) {
+
+#ifdef CONFIG_BOARDCTL_UNIQUEID
+
+  static char s_device_serial[CONFIG_BOARDCTL_UNIQUEID_SIZE * 2 + 1];
+  uint8_t uniqueid[CONFIG_BOARDCTL_UNIQUEID_SIZE];
+
+  if (boardctl(BOARDIOC_UNIQUEID, (uintptr_t)&uniqueid) != OK)
+    {
+      MEMFAULT_LOG_ERROR("Board unique id failed\n");
+    }
+    
+  for (size_t i = 0; i < CONFIG_BOARDCTL_UNIQUEID_SIZE ; i++) 
+    {
+      const uint8_t val = uniqueid[i];
+      const int curr_idx = i * 2;
+      s_device_serial[curr_idx] = prv_int_to_ascii_hex((val >> 4) & 0xf);
+      s_device_serial[curr_idx + 1] = prv_int_to_ascii_hex(val & 0xf);
+    }
+  
+  *info = (sMemfaultDeviceInfo) 
+    {
+      .device_serial = s_device_serial,
+      .software_type = CONFIG_MEMFAULT_SOFTWARE_TYPE,
+      .software_version = CONFIG_MEMFAULT_SOFTWARE_VERSION,
+      .hardware_version = CONFIG_MEMFAULT_HARDWARE_VERSION,
+    };
+    
+#else
+
+  *info = (sMemfaultDeviceInfo) 
+    {
+      .device_serial = CONFIG_MEMFAULT_DEVICE_SERIAL,
+      .software_type = CONFIG_MEMFAULT_SOFTWARE_TYPE,
+      .software_version = CONFIG_MEMFAULT_SOFTWARE_VERSION,
+      .hardware_version = CONFIG_MEMFAULT_HARDWARE_VERSION,
+    };
+
+#endif
+}
+

--- a/ports/nuttx/src/memfault_platform_metrics.c
+++ b/ports/nuttx/src/memfault_platform_metrics.c
@@ -1,0 +1,168 @@
+//! @file memfault_platform_metrics
+//!
+//! Copyright 2022 Memfault, Inc
+//!
+//! Licensed under the Apache License, Version 2.0 (the "License");
+//! you may not use this file except in compliance with the License.
+//! You may obtain a copy of the License at
+//!
+//!     http://www.apache.org/licenses/LICENSE-2.0
+//!
+//! Unless required by applicable law or agreed to in writing, software
+//! distributed under the License is distributed on an "AS IS" BASIS,
+//! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//! See the License for the specific language governing permissions and
+//! limitations under the License.
+//!
+//! Glue layer between the Memfault SDK and the Nuttx platform
+
+
+/*****************************************************************************
+ * Included Files
+ *****************************************************************************/
+
+#include "memfault/components.h"
+#include "memfault/ports/reboot_reason.h"
+
+#include <sys/time.h>
+#include <stdbool.h>
+#include <signal.h>
+#include <sched.h>
+#include <time.h>
+#include <pthread.h>
+#include <errno.h>
+
+#include <nuttx/clock.h>
+
+/****************************************************************************
+ * Preprocessor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/**
+ * @brief Static variable used to store the memfault passed callback
+ * 
+ */
+static MemfaultPlatformTimerCallback *metric_timer_handler;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: memfault_platform_metric_timer_dispatch
+ ****************************************************************************/
+
+/**
+ * @brief Memfault callback function dispatcher
+ * 
+ * @param handler 
+ */
+
+void memfault_platform_metric_timer_dispatch(MemfaultPlatformTimerCallback handler) {
+  if (handler == NULL) {
+    return;
+  }
+  handler();
+}
+
+/****************************************************************************
+ * Name: platform_metrics_timer_handler
+ ****************************************************************************/
+
+/**
+ * @brief  Timer handler
+ * 
+ * @param signo 
+ */
+
+static void platform_metrics_timer_handler(int signo) {
+
+  // Check signo
+  if (signo == SIGALRM) 
+  {
+    memfault_reboot_tracking_reset_crash_count();
+    memfault_platform_metric_timer_dispatch(metric_timer_handler);
+  }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: memfault_platform_metrics_timer_boot
+ ****************************************************************************/
+
+/**
+ * @brief Creates a timer that executes each period_sec seconds and calls 
+ * the callback function.
+ * 
+ * @param period_sec Period in seconds for each execution of the timer
+ * @param callback Called function on timer expiration.
+ * @return true 
+ * @return false 
+ */
+
+bool memfault_platform_metrics_timer_boot(uint32_t period_sec,
+                                          MemfaultPlatformTimerCallback callback) {
+  struct sigaction act;
+  struct sigaction oact;
+  struct sigevent notify;
+  struct itimerspec timer;
+  timer_t timerid;
+  int status;
+
+  metric_timer_handler = (MemfaultPlatformTimerCallback *)callback;
+
+  // Set timer timeout action
+  act.sa_handler = &platform_metrics_timer_handler;
+  act.sa_flags = SA_SIGINFO;
+  (void)sigfillset(&act.sa_mask);
+  (void)sigdelset(&act.sa_mask, SIGALRM);
+  status = sigaction(SIGALRM, &act, &oact);
+  if (status != OK) 
+    {
+      MEMFAULT_LOG_ERROR("Memfault metrics timer sigaction failed, status=%d\n", status);
+      return ERROR;
+    }
+
+  // Create the POSIX timer
+  notify.sigev_notify = SIGEV_SIGNAL;
+  notify.sigev_signo = SIGALRM;
+  notify.sigev_value.sival_int = 0;
+
+#ifdef CONFIG_SIG_EVTHREAD
+
+  notify.sigev_notify_function = NULL;
+  notify.sigev_notify_attributes = NULL;
+
+#endif
+
+  status = timer_create(CLOCK_MONOTONIC, &notify, &timerid);
+  if (status != OK) {
+    MEMFAULT_LOG_ERROR("Memfault timer creation failed, errno=%d\n", errno);
+    return ERROR;
+  }
+
+  // Start the POSIX timer
+  timer.it_value.tv_sec = (period_sec);
+  timer.it_value.tv_nsec = (0);
+  timer.it_interval.tv_sec = (period_sec);
+  timer.it_interval.tv_nsec = (0);
+  status = timer_settime(timerid, 0, &timer, NULL);
+  if (status != OK) 
+  {
+    MEMFAULT_LOG_ERROR("Memfault timer start failed, errno=%d\n", errno);
+    return ERROR;
+  }
+
+  return true;  
+}

--- a/ports/nuttx/src/memfault_platform_reboot_tracking.c
+++ b/ports/nuttx/src/memfault_platform_reboot_tracking.c
@@ -1,0 +1,153 @@
+//! @file memfault_platform_reboot_tracking.c
+//!
+//! Copyright 2022 Memfault, Inc
+//!
+//! Licensed under the Apache License, Version 2.0 (the "License");
+//! you may not use this file except in compliance with the License.
+//! You may obtain a copy of the License at
+//!
+//!     http://www.apache.org/licenses/LICENSE-2.0
+//!
+//! Unless required by applicable law or agreed to in writing, software
+//! distributed under the License is distributed on an "AS IS" BASIS,
+//! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//! See the License for the specific language governing permissions and
+//! limitations under the License.
+//!
+//! Glue layer between the Memfault SDK and the Nuttx platform
+
+/*****************************************************************************
+ * Included Files
+ *****************************************************************************/
+
+#include "memfault/ports/reboot_reason.h"
+
+#include <sys/boardctl.h>
+
+#include "memfault/config.h"
+#include "memfault/core/debug_log.h"
+#include "memfault/core/reboot_reason_types.h"
+#include "memfault/core/sdk_assert.h"
+
+/****************************************************************************
+ * Preprocessor Definitions
+ ****************************************************************************/
+
+#if MEMFAULT_ENABLE_REBOOT_DIAG_DUMP
+#define MEMFAULT_PRINT_RESET_INFO(...) MEMFAULT_LOG_INFO(__VA_ARGS__)
+#else
+#define MEMFAULT_PRINT_RESET_INFO(...)
+#endif
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+MEMFAULT_PUT_IN_SECTION(".noinit.mflt_reboot_tracking")
+static uint8_t s_reboot_tracking[MEMFAULT_REBOOT_TRACKING_REGION_SIZE];
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: memfault_reboot_reason_get
+ ****************************************************************************/
+
+/**
+ * @brief Transform Nuttx provided reset reasons into memfault 
+ * compatible ones.
+ * 
+ * @param info 
+ */
+
+void memfault_reboot_reason_get(sResetBootupInfo *info) {
+
+  uint32_t reset_reason_reg = 0x0;
+  eMemfaultRebootReason reset_reason = kMfltRebootReason_UnknownError;
+
+#ifdef CONFIG_BOARDCTL_RESET_CAUSE
+
+  struct boardioc_reset_cause_s cause;
+  if (boardctl(BOARDIOC_RESET_CAUSE, (uintptr_t)&cause) != OK)
+    {
+      syslog(LOG_ERR, "Failed to get reset cause!\n");
+    }
+
+  reset_reason_reg = (uint32_t)cause.cause;
+
+  MEMFAULT_LOG_INFO("Reset Reason, GetResetReason=0x%" PRIx32, reset_reason_reg);
+  MEMFAULT_PRINT_RESET_INFO("Reset Causes: ");
+
+  switch (reset_reason_reg) {
+    case BOARDIOC_RESETCAUSE_SYS_CHIPPOR:
+      MEMFAULT_PRINT_RESET_INFO(" Power on Reset");
+      reset_reason = kMfltRebootReason_PowerOnReset;
+      break;
+    case BOARDIOC_RESETCAUSE_PIN:
+      MEMFAULT_PRINT_RESET_INFO(" User Reset");
+      reset_reason = kMfltRebootReason_UserReset;
+      break;
+    case BOARDIOC_RESETCAUSE_SYS_BOR:
+      MEMFAULT_PRINT_RESET_INFO(" Brown out");
+      reset_reason = kMfltRebootReason_BrownOutReset;
+      break;
+    case BOARDIOC_RESETCAUSE_CPU_SOFT:
+    case BOARDIOC_RESETCAUSE_CORE_SOFT:
+      MEMFAULT_PRINT_RESET_INFO(" Software");
+      reset_reason = kMfltRebootReason_SoftwareReset;
+      break;
+    case BOARDIOC_RESETCAUSE_SYS_RWDT:
+    case BOARDIOC_RESETCAUSE_CORE_MWDT:
+    case BOARDIOC_RESETCAUSE_CPU_MWDT:
+    case BOARDIOC_RESETCAUSE_CORE_RWDT:
+    case BOARDIOC_RESETCAUSE_CPU_RWDT:
+      MEMFAULT_PRINT_RESET_INFO(" Watchdog");
+      reset_reason = kMfltRebootReason_HardwareWatchdog;
+      break;
+    case BOARDIOC_RESETCAUSE_LOWPOWER:
+      MEMFAULT_PRINT_RESET_INFO(" Low Power Exit");
+      reset_reason = kMfltRebootReason_LowPower;
+      break;
+    case BOARDIOC_RESETCAUSE_CORE_DPSP:
+      MEMFAULT_PRINT_RESET_INFO(" Deep Sleep");
+      reset_reason = kMfltRebootReason_DeepSleep;
+      break;
+    case BOARDIOC_RESETCAUSE_NONE:
+    case BOARDIOC_RESETCAUSE_UNKOWN:
+    default:
+      MEMFAULT_PRINT_RESET_INFO(" Unknown");
+      reset_reason = kMfltRebootReason_Unknown;
+      break;
+  }
+
+#endif
+
+  *info = (sResetBootupInfo) {
+    .reset_reason_reg = reset_reason_reg,
+    .reset_reason = reset_reason,
+  };
+}
+
+/****************************************************************************
+ * Name: memfault_platform_reboot_tracking_boot
+ ****************************************************************************/
+
+/**
+ * @brief Tracking of reoboot causes.
+ * 
+ */
+
+void memfault_platform_reboot_tracking_boot(void) {
+  sResetBootupInfo reset_info = { 0 };
+  memfault_reboot_reason_get(&reset_info);
+  memfault_reboot_tracking_boot(s_reboot_tracking, &reset_info);
+}

--- a/ports/nuttx/src/memfault_platform_time.c
+++ b/ports/nuttx/src/memfault_platform_time.c
@@ -1,0 +1,113 @@
+//! @file memfault_platform_time.c
+//!
+//! Copyright 2022 Memfault, Inc
+//!
+//! Licensed under the Apache License, Version 2.0 (the "License");
+//! you may not use this file except in compliance with the License.
+//! You may obtain a copy of the License at
+//!
+//!     http://www.apache.org/licenses/LICENSE-2.0
+//!
+//! Unless required by applicable law or agreed to in writing, software
+//! distributed under the License is distributed on an "AS IS" BASIS,
+//! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//! See the License for the specific language governing permissions and
+//! limitations under the License.
+//!
+//! Glue layer between the Memfault SDK and the Nuttx platform
+
+/*****************************************************************************
+ * Included Files
+ *****************************************************************************/
+
+#include "memfault/components.h"
+#include "memfault/ports/reboot_reason.h"
+
+#include <sys/time.h>
+#include <stdbool.h>
+#include <signal.h>
+#include <sched.h>
+#include <time.h>
+#include <pthread.h>
+#include <errno.h>
+
+#include <nuttx/clock.h>
+
+/****************************************************************************
+ * Preprocessor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: memfault_platform_time_get_current
+ ****************************************************************************/
+
+/**
+ * @brief Get time since epoch.
+ * 
+ * @param time_val 
+ * @return true 
+ * @return false 
+ */
+
+bool memfault_platform_time_get_current(sMemfaultCurrentTime *time_val) {
+
+  time_t seconds_since_epoch;
+
+  if(time(&seconds_since_epoch) != OK)
+    {
+      MEMFAULT_LOG_ERROR("Current calendar time is not available.");
+      return false;
+    }
+
+  *time_val = (sMemfaultCurrentTime) {
+    .type = kMemfaultCurrentTimeType_UnixEpochTimeSec,
+    .info = {
+      .unix_timestamp_secs = seconds_since_epoch
+    },
+  };
+
+  return true;
+}
+
+/****************************************************************************
+ * Name: memfault_platform_time_get_current
+ ****************************************************************************/
+
+/**
+ * @brief Get time since boot.
+ * 
+ * @return uint64_t 
+ */
+
+uint64_t memfault_platform_get_time_since_boot_ms(void) {
+  
+  uint64_t time;
+  struct timespec tp;
+
+  if(clock_gettime(CLOCK_MONOTONIC, &tp) != OK)
+    {
+      MEMFAULT_LOG_ERROR("Time since boot not available.");
+      return time = 0;
+    }
+
+  time = (((uint64_t) tp.tv_sec) << 32) | ((uint64_t) tp.tv_nsec / NSEC_PER_MSEC);
+
+  return time;
+}
+

--- a/ports/nuttx/src/memfault_platform_unimplemented.c
+++ b/ports/nuttx/src/memfault_platform_unimplemented.c
@@ -1,0 +1,133 @@
+//! @file memfault_platform_uninmplemented.c
+//!
+//! Copyright 2022 Memfault, Inc
+//!
+//! Licensed under the Apache License, Version 2.0 (the "License");
+//! you may not use this file except in compliance with the License.
+//! You may obtain a copy of the License at
+//!
+//!     http://www.apache.org/licenses/LICENSE-2.0
+//!
+//! Unless required by applicable law or agreed to in writing, software
+//! distributed under the License is distributed on an "AS IS" BASIS,
+//! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//! See the License for the specific language governing permissions and
+//! limitations under the License.
+//!
+//! Glue layer between the Memfault SDK and the Nuttx platform
+
+/*****************************************************************************
+ * Included Files
+ *****************************************************************************/
+
+#include "memfault/components.h"
+#include "memfault/ports/reboot_reason.h"
+
+#include <sys/time.h>
+#include <stdbool.h>
+#include <signal.h>
+#include <sched.h>
+#include <time.h>
+#include <pthread.h>
+#include <errno.h>
+
+#include <nuttx/clock.h>
+
+/****************************************************************************
+ * Preprocessor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: memfault_platform_halt_if_debugging
+ ****************************************************************************/
+
+/**
+ * @brief memfault_platform_halt_if_debugging
+ * TODO: Not yet implemented
+ * 
+ * @return MEMFAULT_WEAK 
+ */
+
+MEMFAULT_WEAK
+void memfault_platform_halt_if_debugging(void) {
+  // volatile uint32_t *dhcsr = (volatile uint32_t *)0xE000EDF0;
+  // const uint32_t c_debugen_mask = 0x1;
+
+  // if ((*dhcsr & c_debugen_mask) == 0) {
+  //   // no debugger is attached so return since issuing a breakpoint instruction would trigger a
+  //   // fault
+  //   return;
+  // }
+
+  // // NB: A breakpoint with value 'M' (77) for easy disambiguation from other breakpoints that may
+  // // be used by the system.
+  // MEMFAULT_BREAKPOINT(77);
+}
+
+/****************************************************************************
+ * Name: memfault_platform_sanitize_address_range
+ ****************************************************************************/
+
+/**
+ * @brief memfault_platform_sanitize_address_range
+ * TODO: Not yet implemented
+ * 
+ * @param start_addr 
+ * @param desired_size 
+ * @return size_t 
+ */
+
+size_t memfault_platform_sanitize_address_range(void *start_addr, size_t desired_size) {
+  // static const struct {
+  //   uint32_t start_addr;
+  //   size_t length;
+  // } s_mcu_mem_regions[] = {
+  //   // !FIXME: Update with list of valid memory banks to collect in a coredump
+  //   {.start_addr = 0x00000000, .length = 0xFFFFFFFF},
+  // };
+
+  // for (size_t i = 0; i < MEMFAULT_ARRAY_SIZE(s_mcu_mem_regions); i++) {
+  //   const uint32_t lower_addr = s_mcu_mem_regions[i].start_addr;
+  //   const uint32_t upper_addr = lower_addr + s_mcu_mem_regions[i].length;
+  //   if ((uint32_t)start_addr >= lower_addr && ((uint32_t)start_addr < upper_addr)) {
+  //     return MEMFAULT_MIN(desired_size, upper_addr - (uint32_t)start_addr);
+  //   }
+  // }
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: memfault_platform_reboot
+ ****************************************************************************/
+
+/**
+ * @brief memfault_platform_reboot
+ * TODO: Not yet implemented
+ */
+
+//! Last function called after a coredump is saved. Should perform
+//! any final cleanup and then reset the device
+void memfault_platform_reboot(void) {
+  // !FIXME: Perform any final system cleanup here
+
+  // !FIXME: Reset System
+  // NVIC_SystemReset()
+  while (1) { } // unreachable
+}


### PR DESCRIPTION
**RATIONALE:**
This PR makes a first porting of memfault-sdk for the Nuttx platform. 

It implements the necessary platform specific functions to compiling the following memfault components:

- Core
- Utils
- Panics
- Metrics

**KNOWN LIMITATIONS**
On this version, the functions under `memfault_platform_unimplemented.c` file are stubbed, and its functionality is reduced, the affected functions are:

- `memfault_platform_halt_if_debugging`
- `memfault_platform_sanitize_address_range`
- `memfault_platform_reboot`


**TESTING**
This porting is tested for the latest version of Nuttx (commit hash: 1ecaa4e6) running into a Nucleo-H743ZI board.



Signed-off-by: Andrés Sánchez Pascual <tito97_sp@hotmail.com>