### PR TITLE
Allow the `memfault coredump --region` command to take GDB variables as arguments

### DIFF
--- a/scripts/memfault_gdb.py
+++ b/scripts/memfault_gdb.py
@@ -1438,7 +1438,10 @@ Proceed? [y/n]
         )
 
         def _auto_int(x):
-            return int(x, 0)
+            try:
+                return int(x, 0)
+            except ValueError:
+                return int(gdb.parse_and_eval(x))
 
         parser.add_argument(
             "--region",


### PR DESCRIPTION
Currently, the arguments for --region must be integers.
Passing `memfault coredump --region (uint32_t)&_ram_start (uint32_t)&_ram_size` or `memfault coredump --region $coredump_start $coredump_size` will result in errors.
This change will evaluate the arguments if they are not integers :D