### PR TITLE
Remove zephyr.h include in Zephyr RTOS port

### DIFF
--- a/examples/nrf-connect-sdk/nrf9160/memfault_demo_app/src/main.c
+++ b/examples/nrf-connect-sdk/nrf9160/memfault_demo_app/src/main.c
@@ -14,7 +14,7 @@
 
 #include <string.h>
 
-#include <zephyr.h>
+#include <kernel.h>
 #include <device.h>
 #include <sys/printk.h>
 

--- a/examples/nrf-connect-sdk/nrf9160/memfault_demo_app/src/watchdog.c
+++ b/examples/nrf-connect-sdk/nrf9160/memfault_demo_app/src/watchdog.c
@@ -11,7 +11,7 @@
 #include <device.h>
 #include <drivers/watchdog.h>
 #include <version.h>
-#include <zephyr.h>
+#include <kernel.h>
 
 #include "memfault/components.h"
 

--- a/examples/zephyr/qemu/qemu-app/src/main.c
+++ b/examples/zephyr/qemu/qemu-app/src/main.c
@@ -10,7 +10,7 @@
 #include <drivers/gpio.h>
 #include <shell/shell.h>
 #include <logging/log.h>
-#include <zephyr.h>
+#include <kernel.h>
 
 #include "memfault/components.h"
 

--- a/examples/zephyr/stm32l4_disco/apps/memfault_demo_app/src/main.c
+++ b/examples/zephyr/stm32l4_disco/apps/memfault_demo_app/src/main.c
@@ -3,7 +3,7 @@
 //! Copyright (c) Memfault, Inc.
 //! See License.txt for details
 
-#include <zephyr.h>
+#include <kernel.h>
 #include <logging/log.h>
 LOG_MODULE_REGISTER(mflt_app, LOG_LEVEL_DBG);
 

--- a/ports/zephyr/common/memfault_http_periodic_upload.c
+++ b/ports/zephyr/common/memfault_http_periodic_upload.c
@@ -11,7 +11,6 @@
 #include <init.h>
 #include <kernel.h>
 #include <random/rand32.h>
-#include <zephyr.h>
 
 #if CONFIG_MEMFAULT_HTTP_PERIODIC_UPLOAD_USE_DEDICATED_WORKQUEUE
 static K_THREAD_STACK_DEFINE(

--- a/ports/zephyr/common/memfault_platform_coredump_regions.c
+++ b/ports/zephyr/common/memfault_platform_coredump_regions.c
@@ -10,7 +10,6 @@
 #include "memfault/panics/platform/coredump.h"
 #include "memfault/panics/arch/arm/cortex_m.h"
 
-#include <zephyr.h>
 #include <kernel.h>
 #include <kernel_structs.h>
 

--- a/ports/zephyr/common/memfault_platform_http.c
+++ b/ports/zephyr/common/memfault_platform_http.c
@@ -11,7 +11,6 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <zephyr.h>
 
 #include "memfault/core/compiler.h"
 #include "memfault/core/data_packetizer.h"

--- a/ports/zephyr/common/memfault_platform_metrics.c
+++ b/ports/zephyr/common/memfault_platform_metrics.c
@@ -3,7 +3,7 @@
 //! Copyright (c) Memfault, Inc.
 //! See License.txt for details
 
-#include <zephyr.h>
+#include <kernel.h>
 
 #include <stdbool.h>
 

--- a/ports/zephyr/common/memfault_software_watchdog.c
+++ b/ports/zephyr/common/memfault_software_watchdog.c
@@ -11,7 +11,7 @@
 #include "memfault/panics/assert.h"
 #include "memfault/ports/watchdog.h"
 
-#include <zephyr.h>
+#include <kernel.h>
 
 static void prv_software_watchdog_timeout(struct k_timer *dummy) {
   MEMFAULT_SOFTWARE_WATCHDOG();

--- a/ports/zephyr/common/memfault_zephyr_ram_regions.c
+++ b/ports/zephyr/common/memfault_zephyr_ram_regions.c
@@ -8,7 +8,6 @@
 
 #include "memfault/ports/zephyr/coredump.h"
 
-#include <zephyr.h>
 #include <kernel.h>
 #include <kernel_structs.h>
 #include <version.h>


### PR DESCRIPTION
The zephyr.h header has been deprecated for two releases and
finally removed for v3.4.

