### PR TITLE
rename z_NmiHandlerSet to z_arm_nmi_set_handler

### DIFF
--- a/ports/zephyr/v2.4/memfault_fault_handler.c
+++ b/ports/zephyr/v2.4/memfault_fault_handler.c
@@ -28,8 +28,8 @@
 // Since we don't use the arguments we match anything with () to avoid
 // compiler warnings and share the same bootup logic
 static int prv_install_nmi_handler() {
-  extern void z_NmiHandlerSet(void (*pHandler)(void));
-  z_NmiHandlerSet(MEMFAULT_EXC_HANDLER_NMI);
+  extern void z_arm_nmi_set_handler(void (*pHandler)(void));
+  z_arm_nmi_set_handler(MEMFAULT_EXC_HANDLER_NMI);
   return 0;
 }
 


### PR DESCRIPTION
This should fix #49 