### PR TITLE
docs: Replace wrong command in ESP32 example

### DIFF
--- a/examples/esp32/README.md
+++ b/examples/esp32/README.md
@@ -228,7 +228,7 @@ I (116450) connect: Connecting to '<SSID>'
 Then post the data:
 
 ```plaintext
-esp32> post_core
+esp32> post_chunks
 I (12419) mflt: Posting Memfault Data...
 I (12419) mflt: Result: 0
 ```


### PR DESCRIPTION
I just played around with the ESP32 example and noticed that the mentioned command `post_core` does not exist.