### PR TITLE
core: build_id: support alternate GNU build ID sources

### DIFF
--- a/components/core/src/memfault_build_id.c
+++ b/components/core/src/memfault_build_id.c
@@ -23,7 +23,9 @@ MEMFAULT_BUILD_ID_QUALIFIER sMemfaultBuildIdStorage g_memfault_build_id = {
   .type = kMemfaultBuildIdType_GnuBuildIdSha1,
   .len = sizeof(sMemfaultElfNoteSection),
   .short_len = MEMFAULT_EVENT_INCLUDED_BUILD_ID_SIZE_BYTES,
+#ifndef MEMFAULT_GNU_BUILD_ID_CUSTOM
   .storage = __start_gnu_build_id_start,
+#endif
   .sdk_version = MEMFAULT_SDK_VERSION,
 };
 #else

--- a/components/core/src/memfault_core_utils.c
+++ b/components/core/src/memfault_core_utils.c
@@ -22,9 +22,13 @@ static const void *prv_get_build_id_start_pointer(void) {
     case kMemfaultBuildIdType_MemfaultBuildIdSha1:
       return g_memfault_build_id.storage;
     case kMemfaultBuildIdType_GnuBuildIdSha1: {
+#if MEMFAULT_GNU_BUILD_ID_CUSTOM
+      return memfault_gnu_build_id_get();
+#else
       const sMemfaultElfNoteSection *elf =
           (const sMemfaultElfNoteSection *)g_memfault_build_id.storage;
       return &elf->namedata[elf->namesz]; // Skip over { 'G', 'N', 'U', '\0' }
+#endif
     }
     case kMemfaultBuildIdType_None:
     default:

--- a/components/include/memfault/core/build_info.h
+++ b/components/include/memfault/core/build_info.h
@@ -47,6 +47,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "memfault/config.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -83,6 +85,11 @@ bool memfault_build_id_get_string(char *out_buf, size_t buf_len);
 //!   Memfault Build ID: 000102030405060708090a0b0c0d0e0f10111213
 //!   GNU Build ID: 58faeeb01696afbfb4f790c63b77c80f89972989
 void memfault_build_info_dump(void);
+
+#ifdef MEMFAULT_GNU_BUILD_ID_CUSTOM
+//! Invoked by memfault library to query the GNU build ID when MEMFAULT_GNU_BUILD_ID_CUSTOM
+const void *memfault_gnu_build_id_get(void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/ports/zephyr/Kconfig
+++ b/ports/zephyr/Kconfig
@@ -40,6 +40,12 @@ config MEMFAULT_USER_CONFIG_SILENT_FAIL
           memfault_metrics_heartbeat_config.def
           memfault_trace_reason_user_config.def
 
+config MEMFAULT_GNU_BUILD_ID_CUSTOM
+        bool "Provide a custom pointer for GNU build ID through memfault_gnu_build_id_get()"
+        help
+          When enabled the application is expected to provide the GNU build ID
+          through memfault_gnu_build_id_get.
+
 config MEMFAULT_COREDUMP_STORAGE_CUSTOM
         bool
         default n

--- a/ports/zephyr/common/CMakeLists.txt
+++ b/ports/zephyr/common/CMakeLists.txt
@@ -50,11 +50,13 @@ zephyr_library_sources_ifdef(CONFIG_MEMFAULT_HTTP_PERIODIC_UPLOAD memfault_http_
 # by placing them in special linker sections
 zephyr_linker_sources(NOINIT memfault-no-init.ld)
 
-zephyr_linker_sources(SECTIONS memfault-build-id.ld)
+if(NOT CONFIG_MEMFAULT_GNU_BUILD_ID_CUSTOM)
+  zephyr_linker_sources(SECTIONS memfault-build-id.ld)
 
-# Override the default Zephyr setting which disables the GNU Build ID
-#   https://github.com/zephyrproject-rtos/zephyr/blob/d7ee114106eab485688223d97a49813d33b4cf21/cmake/linker/ld/target_base.cmake#L16
-zephyr_ld_options("-Wl,--build-id")
+  # Override the default Zephyr setting which disables the GNU Build ID
+  #   https://github.com/zephyrproject-rtos/zephyr/blob/d7ee114106eab485688223d97a49813d33b4cf21/cmake/linker/ld/target_base.cmake#L16
+  zephyr_ld_options("-Wl,--build-id")
+endif()
 
 if(CONFIG_MEMFAULT_HEAP_STATS AND CONFIG_HEAP_MEM_POOL_SIZE GREATER 0)
   zephyr_ld_options(-Wl,--wrap=k_malloc)

--- a/ports/zephyr/config/memfault_zephyr_platform_config.h
+++ b/ports/zephyr/config/memfault_zephyr_platform_config.h
@@ -25,6 +25,12 @@ extern "C" {
 // enables the Memfault cloud to identify and surface when this happens! Below
 // requires the "-Wl,--build-id" flag.
 #define MEMFAULT_USE_GNU_BUILD_ID 1
+
+#if CONFIG_MEMFAULT_GNU_BUILD_ID_CUSTOM
+// The build system already generates the GNU build ID.
+// Link it to Memfault via the memfault_gnu_build_id_get() call.
+#define MEMFAULT_GNU_BUILD_ID_CUSTOM 1
+#endif
 #endif
 
 // We need to define MEMFAULT_COREDUMP_COLLECT_LOG_REGIONS=1 for the logs to


### PR DESCRIPTION
External build systems may already be enabling GNU build ID, in which case the Memfault provided implementation either breaks the upstream version or doesn't work.

By enabling `MEMFAULT_GNU_BUILD_ID_CUSTOM` the query for the build ID is offloaded to the application.

This enables integration with solutions such as https://github.com/zephyrproject-rtos/zephyr/pull/51532, and presumably the final result of https://github.com/zephyrproject-rtos/zephyr/pull/54464