### PR TITLE
core: build_id: support alternate GNU build ID sources

### DIFF
--- a/components/core/src/memfault_build_id.c
+++ b/components/core/src/memfault_build_id.c
@@ -17,13 +17,13 @@
 #if MEMFAULT_USE_GNU_BUILD_ID
 
 // Note: This variable is emitted by the linker script
-extern uint8_t __start_gnu_build_id_start[];
+extern uint8_t MEMFAULT_GNU_BUILD_ID_SYMBOL[];
 
 MEMFAULT_BUILD_ID_QUALIFIER sMemfaultBuildIdStorage g_memfault_build_id = {
   .type = kMemfaultBuildIdType_GnuBuildIdSha1,
   .len = sizeof(sMemfaultElfNoteSection),
   .short_len = MEMFAULT_EVENT_INCLUDED_BUILD_ID_SIZE_BYTES,
-  .storage = __start_gnu_build_id_start,
+  .storage = MEMFAULT_GNU_BUILD_ID_SYMBOL,
   .sdk_version = MEMFAULT_SDK_VERSION,
 };
 #else

--- a/components/include/memfault/default_config.h
+++ b/components/include/memfault/default_config.h
@@ -26,6 +26,10 @@ extern "C" {
 #define MEMFAULT_USE_GNU_BUILD_ID 0
 #endif
 
+#ifndef MEMFAULT_GNU_BUILD_ID_SYMBOL
+#define MEMFAULT_GNU_BUILD_ID_SYMBOL __start_gnu_build_id_start
+#endif
+
 //! Allows users to dial in the correct amount of storage for their
 //! software version + build ID string.
 #ifndef MEMFAULT_UNIQUE_VERSION_MAX_LEN

--- a/ports/zephyr/CMakeLists.txt
+++ b/ports/zephyr/CMakeLists.txt
@@ -36,7 +36,7 @@ if(CONFIG_MEMFAULT)
   # Be sure to use the Zephyr override config file if config'd in. This file
   # will include the base config file. zephyr_compile_definitions() use
   # INTERFACE as the scope so users will pickup this define as expected.
-  zephyr_compile_definitions(MEMFAULT_PLATFORM_CONFIG_FILE=\"memfault_zephyr_platform_config.h\")
+  zephyr_compile_definitions(MEMFAULT_PLATFORM_CONFIG_FILE=CONFIG_MEMFAULT_PLATFORM_CONFIG)
 
   # We automatically collect some Zephyr kernel metrics from a custom Zephyr port def file. The
   # Zephyr port def file will pull in the user's file via include directive.

--- a/ports/zephyr/Kconfig
+++ b/ports/zephyr/Kconfig
@@ -11,6 +11,12 @@ config MEMFAULT
 
 if MEMFAULT
 
+config MEMFAULT_PLATFORM_CONFIG
+        string "Platform configuration file"
+        default "memfault_zephyr_platform_config.h"
+        help
+          Select the Memfault configuration file to use
+
 config MEMFAULT_CACHE_FAULT_REGS
         bool "MEMFAULT Cache ARM fault registers"
         default y

--- a/ports/zephyr/Kconfig
+++ b/ports/zephyr/Kconfig
@@ -46,6 +46,13 @@ config MEMFAULT_USER_CONFIG_SILENT_FAIL
           memfault_metrics_heartbeat_config.def
           memfault_trace_reason_user_config.def
 
+config MEMFAULT_GNU_BUILD_ID_EXTERNAL
+        bool "GNU build ID is already being linked externally"
+        help
+          When enabled the application is already configuring the linker to generate
+          a GNU build ID. The expected symbol name can be set in the platform config
+          with MEMFAULT_GNU_BUILD_ID_SYMBOL.
+
 config MEMFAULT_COREDUMP_STORAGE_CUSTOM
         bool
         default n

--- a/ports/zephyr/common/CMakeLists.txt
+++ b/ports/zephyr/common/CMakeLists.txt
@@ -50,11 +50,13 @@ zephyr_library_sources_ifdef(CONFIG_MEMFAULT_HTTP_PERIODIC_UPLOAD memfault_http_
 # by placing them in special linker sections
 zephyr_linker_sources(NOINIT memfault-no-init.ld)
 
-zephyr_linker_sources(SECTIONS memfault-build-id.ld)
+if(NOT CONFIG_MEMFAULT_GNU_BUILD_ID_EXTERNAL)
+  zephyr_linker_sources(SECTIONS memfault-build-id.ld)
 
-# Override the default Zephyr setting which disables the GNU Build ID
-#   https://github.com/zephyrproject-rtos/zephyr/blob/d7ee114106eab485688223d97a49813d33b4cf21/cmake/linker/ld/target_base.cmake#L16
-zephyr_ld_options("-Wl,--build-id")
+  # Override the default Zephyr setting which disables the GNU Build ID
+  #   https://github.com/zephyrproject-rtos/zephyr/blob/d7ee114106eab485688223d97a49813d33b4cf21/cmake/linker/ld/target_base.cmake#L16
+  zephyr_ld_options("-Wl,--build-id")
+endif()
 
 if(CONFIG_MEMFAULT_HEAP_STATS AND CONFIG_HEAP_MEM_POOL_SIZE GREATER 0)
   zephyr_ld_options(-Wl,--wrap=k_malloc)


### PR DESCRIPTION
External build systems may already be enabling GNU build ID, in which case the Memfault provided implementation either breaks the upstream version or doesn't work.

`CONFIG_MEMFAULT_PLATFORM_CONFIG` enables users to override the configuration file if they desire.

By setting `CONFIG_MEMFAULT_GNU_BUILD_ID_EXTERNAL=y` and appropriately configuring `MEMFAULT_GNU_BUILD_ID_SYMBOL`, `memfault_build_id.c` will pick up whatever symbol is being created by the build system.

This enables integration with solutions such as https://github.com/zephyrproject-rtos/zephyr/pull/51532, and presumably the final result of https://github.com/zephyrproject-rtos/zephyr/pull/54464