### PR TITLE
panics: fault_handling_arm: optional handler return

### DIFF
--- a/components/include/memfault/default_config.h
+++ b/components/include/memfault/default_config.h
@@ -391,6 +391,12 @@ extern "C" {
 #define MEMFAULT_PLATFORM_FAULT_HANDLER_CUSTOM  0
 #endif
 
+#ifndef MEMFAULT_FAULT_HANDLER_RETURN
+// If enabled, memfault_fault_handler will return back to OS
+// exception handling code instead of rebooting the device.
+#define MEMFAULT_FAULT_HANDLER_RETURN 0
+#endif 
+
 //
 // Http Configuration Options
 //

--- a/components/panics/src/memfault_fault_handling_arm.c
+++ b/components/panics/src/memfault_fault_handling_arm.c
@@ -177,8 +177,10 @@ void memfault_fault_handler(const sMfltRegState *regs, eMemfaultRebootReason rea
     memfault_reboot_tracking_mark_coredump_saved();
   }
 
+#if !MEMFAULT_FAULT_HANDLER_RETURN
   memfault_platform_reboot();
   MEMFAULT_UNREACHABLE;
+#endif
 }
 
 

--- a/ports/zephyr/v2.4/memfault_fault_handler.c
+++ b/ports/zephyr/v2.4/memfault_fault_handler.c
@@ -78,6 +78,11 @@ void __wrap_z_fatal_error(unsigned int reason, const z_arch_esf_t *esf) {
   };
 
   memfault_fault_handler(&reg, kMfltRebootReason_HardFault);
+
+#if MEMFAULT_FAULT_HANDLER_RETURN
+  void __real_z_fatal_error(unsigned int reason, const z_arch_esf_t *esf);
+  __real_z_fatal_error(reason, esf);
+#endif
 }
 
 MEMFAULT_WEAK


### PR DESCRIPTION
Add a new configuration option that enables returning back to the OS fault handler from `memfault_fault_handler`, instead of rebooting immediately.

Fixes #59