### PR TITLE
ports: zephyr: use cmsis_core.h for Zephyr > 3.4

### DIFF
--- a/ports/zephyr/common/memfault_platform_coredump_regions.c
+++ b/ports/zephyr/common/memfault_platform_coredump_regions.c
@@ -15,7 +15,9 @@
 #include "memfault/panics/platform/coredump.h"
 #include "memfault/ports/zephyr/version.h"
 
-#if MEMFAULT_ZEPHYR_VERSION_GT(2, 1)
+#if MEMFAULT_ZEPHYR_VERSION_GT(3, 4)
+  #include <cmsis_core.h>
+#elif MEMFAULT_ZEPHYR_VERSION_GT(2, 1)
   #include MEMFAULT_ZEPHYR_INCLUDE(arch/arm/aarch32/cortex_m/cmsis.h)
 #else
   #include MEMFAULT_ZEPHYR_INCLUDE(arch/arm/cortex_m/cmsis.h)


### PR DESCRIPTION
CMSIS glue code in Zephyr can now be used by including cmsis_core.h header. Old headers are deprecated.