### PR TITLE
RFC: Zephyr: In PR #60031 aarch32 directory in favor of cmsis_core.h

### DIFF
--- a/ports/zephyr/common/memfault_platform_coredump_regions.c
+++ b/ports/zephyr/common/memfault_platform_coredump_regions.c
@@ -15,7 +15,7 @@
 #include "memfault/ports/zephyr/version.h"
 
 #if MEMFAULT_ZEPHYR_VERSION_GT(2, 1)
-  #include <arch/arm/aarch32/cortex_m/cmsis.h>
+  #include <cmsis_core.h>
 #else
   #include <arch/arm/cortex_m/cmsis.h>
 #endif

--- a/ports/zephyr/v2.4/memfault_fault_handler.c
+++ b/ports/zephyr/v2.4/memfault_fault_handler.c
@@ -23,7 +23,7 @@
 // Starting in v3.4, the handler set function was renamed and the declaration
 // added to a public header
 #if MEMFAULT_ZEPHYR_VERSION_GT(3, 3)
-  #include <arch/arm/aarch32/nmi.h>
+  #include <cmsis_core.h>
   #define MEMFAULT_ZEPHYR_NMI_HANDLER_SET z_arm_nmi_set_handler
 #else
   #define MEMFAULT_ZEPHYR_NMI_HANDLER_SET z_NmiHandlerSet


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/60031

This is required for current main and upcoming Zephyr release v.3.5 (Scheduled for  2023/10/20).

Probably missed some locations. This is mostly to unblock our CI.

This is also not compatible with current version 3.4 or early. Needs a proper fix.