### PR TITLE
metrics: timer: update timer value on read

### DIFF
--- a/components/metrics/src/memfault_metrics.c
+++ b/components/metrics/src/memfault_metrics.c
@@ -728,6 +728,7 @@ int memfault_metrics_heartbeat_timer_read(MemfaultMetricId key, uint32_t *read_v
   memfault_lock();
   {
     union MemfaultMetricValue *value;
+    prv_find_timer_metric_and_update(key, kMemfaultTimerOp_ForceValueUpdate);
     rv = prv_find_key_of_type(key, kMemfaultMetricType_Timer, &value);
     if (rv == 0) {
       *read_val = value->u32;

--- a/tests/src/test_memfault_heartbeat_metrics.cpp
+++ b/tests/src/test_memfault_heartbeat_metrics.cpp
@@ -238,15 +238,12 @@ TEST(MemfaultHeartbeatMetrics, Test_TimerHeartBeatValueSimple) {
   LONGS_EQUAL(10, val);
 }
 
-TEST(memfaultHeartbeatMetrics, Test_TimerHeartBeatReadWhileRunning)
+TEST(MemfaultHeartbeatMetrics, Test_TimerHeartBeatReadWhileRunning)
 {
   MemfaultMetricId key = MEMFAULT_METRICS_KEY(test_key_timer);
-  // no-op
-  int rv = memfault_metrics_heartbeat_timer_stop(key);
-  CHECK(rv != 0);
 
   // start the timer
-  rv = memfault_metrics_heartbeat_timer_start(key);
+  int rv = memfault_metrics_heartbeat_timer_start(key);
   LONGS_EQUAL(0, rv);
 
   // read while running
@@ -258,7 +255,7 @@ TEST(memfaultHeartbeatMetrics, Test_TimerHeartBeatReadWhileRunning)
   // stop the timer
   prv_fake_time_incr(9);
   rv = memfault_metrics_heartbeat_timer_stop(key);
-  LONG_EQUAL(0, rv);
+  LONGS_EQUAL(0, rv);
 
   memfault_metrics_heartbeat_timer_read(key, &val);
   LONGS_EQUAL(19, val);

--- a/tests/src/test_memfault_heartbeat_metrics.cpp
+++ b/tests/src/test_memfault_heartbeat_metrics.cpp
@@ -238,6 +238,32 @@ TEST(MemfaultHeartbeatMetrics, Test_TimerHeartBeatValueSimple) {
   LONGS_EQUAL(10, val);
 }
 
+TEST(memfaultHeartbeatMetrics, Test_TimerHeartBeatReadWhileRunning)
+{
+  MemfaultMetricId key = MEMFAULT_METRICS_KEY(test_key_timer);
+  // no-op
+  int rv = memfault_metrics_heartbeat_timer_stop(key);
+  CHECK(rv != 0);
+
+  // start the timer
+  rv = memfault_metrics_heartbeat_timer_start(key);
+  LONGS_EQUAL(0, rv);
+
+  // read while running
+  uint32_t val;
+  prv_fake_time_incr(10);
+  memfault_metrics_heartbeat_timer_read(key, &val);
+  LONGS_EQUAL(10, val);
+
+  // stop the timer
+  prv_fake_time_incr(9);
+  rv = memfault_metrics_heartbeat_timer_stop(key);
+  LONG_EQUAL(0, rv);
+
+  memfault_metrics_heartbeat_timer_read(key, &val);
+  LONGS_EQUAL(19, val);
+}
+
 TEST(MemfaultHeartbeatMetrics, Test_TimerHeartBeatValueRollover) {
   MemfaultMetricId key = MEMFAULT_METRICS_KEY(test_key_timer);
 


### PR DESCRIPTION
The (debug) API `memfault_metrics_heartbeat_timer_read` does not force an update of the timer value, which means that if it is used while the timer is running, the value read is stale.

This change forces an update when the timer is read.