### PR TITLE
fix: compiler warnings

### DIFF
--- a/ports/zephyr/common/memfault_zephyr_ram_regions.c
+++ b/ports/zephyr/common/memfault_zephyr_ram_regions.c
@@ -217,16 +217,16 @@ size_t memfault_zephyr_get_task_regions(sMfltCoredumpRegion *regions, size_t num
       ;
 
 #if defined(CONFIG_THREAD_STACK_INFO)
+  #if CONFIG_MEMFAULT_COREDUMP_FULL_THREAD_STACKS
+    // Capture the entire stack for this thread
+    size_t stack_size_to_collect = thread->stack_info.size;
+    sp = (void *)thread->stack_info.start;
+  #else
     // We know where the top of the stack is. Use that information to shrink
     // the area we need to collect if less than CONFIG_MEMFAULT_COREDUMP_STACK_SIZE_TO_COLLECT
     // is in use
     const uint32_t stack_top = thread->stack_info.start + thread->stack_info.size;
 
-  #if CONFIG_MEMFAULT_COREDUMP_FULL_THREAD_STACKS
-    // Capture the entire stack for this thread
-    size_t stack_size_to_collect = thread->stack_info.size;
-    sp = thread->stack_info.start;
-  #else
     size_t stack_size_to_collect =
       MEMFAULT_MIN(stack_top - (uint32_t)sp, CONFIG_MEMFAULT_COREDUMP_STACK_SIZE_TO_COLLECT);
   #endif


### PR DESCRIPTION
explicit cast & unused variable