### PR TITLE
always clean up ESP HTTP client

### DIFF
--- a/ports/esp_idf/memfault/common/memfault_platform_http_client.c
+++ b/ports/esp_idf/memfault/common/memfault_platform_http_client.c
@@ -125,10 +125,7 @@ sMfltHttpClient *memfault_platform_http_client_create(void) {
 
 int memfault_platform_http_client_destroy(sMfltHttpClient *_client) {
   esp_http_client_handle_t client = (esp_http_client_handle_t)_client;
-  esp_err_t err = esp_http_client_close(client);
-  if (err == ESP_OK) {
-    err = esp_http_client_cleanup(client);
-  }
+  esp_err_t err = esp_http_client_cleanup(client);
   if (err == ESP_OK) {
     return 0;
   }


### PR DESCRIPTION
If a device is connected to a wifi access point, but the AP isn't connected to the internet, then a call to *memfault_esp_port_http_client_post_data()* will leak memory if data is available to post, because *memfault_platform_http_client_destroy()*'s call to *esp_http_client_close()* will fail, so it won't call *esp_http_client_cleanup()* to free memory associated with the HTTP client.

In my testing on a device that calls *memfault_esp_port_http_client_post_data()* once per minute, this leaks ~2.5K bytes per invocation. (Eventually the device runs out of heap and crashes.)

Since *esp_http_client_cleanup()* itself calls *esp_http_client_close()* (and ignores its return value), it seems like this could be fixed by making *memfault_platform_http_client_destroy()* call *esp_http_client_cleanup()* unconditionally, without first calling *esp_http_client_close()* and checking its return value.