### PR TITLE
chore(zephyr): global CSTD property is deprecated

### DIFF
--- a/ports/zephyr/Kconfig
+++ b/ports/zephyr/Kconfig
@@ -219,6 +219,8 @@ config MEMFAULT_REBOOT_REASON_CUSTOM_ENABLE
 config MEMFAULT_COMPACT_LOG
         bool "Enable compact logging"
         default n
+        select REQUIRES_STD_C11
+        select GNU_C_EXTENSIONS
         help
           When enabled, the Memfault SDK will use a compact representation
           for log messages written using the 'MEMFAULT_LOG_x' macros. Find more

--- a/ports/zephyr/common/CMakeLists.txt
+++ b/ports/zephyr/common/CMakeLists.txt
@@ -64,7 +64,10 @@ if (CONFIG_MEMFAULT_COMPACT_LOG)
   zephyr_linker_sources(SECTIONS memfault-compact-log.ld)
   # Compact logs requires a minimum C standard of gnu11, due to use of GNU
   # extensions and C11 features.
-  set_property(GLOBAL PROPERTY CSTD gnu11)
+  # Use global property CSTD if not already set by Zephyr config.
+  if (NOT (CONFIG_REQUIRES_STD_C11 AND CONFIG_GNU_C_EXTENSIONS))
+    set_property(GLOBAL PROPERTY CSTD gnu11)
+  endif()
 endif()
 
 if(CONFIG_MEMFAULT_HEAP_STATS AND CONFIG_HEAP_MEM_POOL_SIZE GREATER 0)


### PR DESCRIPTION
select required C standard and GNU extensions for compact logs directly in KConfig.
Use global CSTD if config `REQUIRES_STD_C11` & `CONFIG_GNU_C_EXTENSIONS`
 are not selected, for Zephyr versions older than 3.7.0.

This removes the warning during compilation while still ensuring that C11 + GNU extensions
are still enabled.

Please make sure it's not a breaking change. 🙏 