### PR TITLE
Fix MEMFAULT_PACKED_ENUM compile failure with IAR

### DIFF
--- a/components/include/memfault/core/compiler_armcc.h
+++ b/components/include/memfault/core/compiler_armcc.h
@@ -16,6 +16,7 @@ extern "C" {
 #endif
 
 #define MEMFAULT_PACKED __packed
+#define MEMFAULT_PACKED_ENUM enum MEMFAULT_PACKED
 #define MEMFAULT_PACKED_STRUCT MEMFAULT_PACKED struct
 #define MEMFAULT_NORETURN __declspec(noreturn)
 #define MEMFAULT_NAKED_FUNC __asm

--- a/components/include/memfault/core/compiler_gcc.h
+++ b/components/include/memfault/core/compiler_gcc.h
@@ -16,6 +16,7 @@ extern "C" {
 #endif
 
 #define MEMFAULT_PACKED __attribute__((packed))
+#define MEMFAULT_PACKED_ENUM enum MEMFAULT_PACKED
 #define MEMFAULT_PACKED_STRUCT struct MEMFAULT_PACKED
 //! MEMFAULT_NORETURN is only intended to be overridden in unit tests, if needed
 #if !defined(MEMFAULT_NORETURN)

--- a/components/include/memfault/core/compiler_iar.h
+++ b/components/include/memfault/core/compiler_iar.h
@@ -18,6 +18,7 @@ extern "C" {
 #include "intrinsics.h"
 
 #define MEMFAULT_PACKED __packed
+#define MEMFAULT_PACKED_ENUM MEMFAULT_PACKED enum
 #define MEMFAULT_PACKED_STRUCT MEMFAULT_PACKED struct
 #define MEMFAULT_NORETURN __noreturn
 #define MEMFAULT_NAKED_FUNC

--- a/components/include/memfault/core/compiler_ti_arm.h
+++ b/components/include/memfault/core/compiler_ti_arm.h
@@ -18,6 +18,7 @@ extern "C" {
 #include <inttypes.h>
 
 #define MEMFAULT_PACKED __attribute__((packed))
+#define MEMFAULT_PACKED_ENUM enum MEMFAULT_PACKED
 #define MEMFAULT_PACKED_STRUCT struct MEMFAULT_PACKED
 #define MEMFAULT_NORETURN __attribute__((noreturn))
 #define MEMFAULT_NAKED_FUNC __attribute__((naked))

--- a/components/include/memfault/core/reboot_reason_types.h
+++ b/components/include/memfault/core/reboot_reason_types.h
@@ -26,7 +26,7 @@ extern "C" {
 
 //! This enum must be packed to prevent compiler optimizations in instructions which load an
 //! eMemfaultRebootReason.
-typedef enum MEMFAULT_PACKED MfltResetReason {
+typedef MEMFAULT_PACKED_ENUM MfltResetReason {
   // A reboot reason was not determined either by hardware or a previously marked reboot reason
   // This reason is classified as a crash when calculating the operational_crashfree_hours metric
   kMfltRebootReason_Unknown = 0x0000,


### PR DESCRIPTION
 - Use `__packed enum` instead of `enum __packed` for IAR