### PR TITLE
zephyr: Align with net_mgmt API change

### DIFF
--- a/ports/zephyr/common/memfault_platform_metrics.c
+++ b/ports/zephyr/common/memfault_platform_metrics.c
@@ -206,7 +206,12 @@ static void prv_record_wifi_connection_metrics(struct net_if *iface) {
   MEMFAULT_METRIC_SET_STRING(wifi_ap_oui, oui);
 }
 
-static void prv_wifi_event_callback(struct net_mgmt_event_callback *cb, uint32_t mgmt_event,
+static void prv_wifi_event_callback(struct net_mgmt_event_callback *cb,
+#if MEMFAULT_ZEPHYR_VERSION_GT(4, 1)
+                                    uint64_t mgmt_event,
+#else
+                                    uint32_t mgmt_event,
+#endif
                                     struct net_if *iface) {
   switch (mgmt_event) {
     case NET_EVENT_WIFI_CONNECT_RESULT: {


### PR DESCRIPTION
The net_mgmt event type was changed from 32-bit to 64-bit value in Zephyr commit [5a9a39caf3bf5195a38194bb844a428eaa7f2bb8 ](https://github.com/zephyrproject-rtos/zephyr/commit/5a9a39caf3bf5195a38194bb844a428eaa7f2bb8) (Zephyr v4.1.99) so the net_mgmt callback function needs to be aligned.