### PR TITLE
1mb cdr upload

### DIFF
--- a/ports/zephyr/common/memfault_platform_http.c
+++ b/ports/zephyr/common/memfault_platform_http.c
@@ -388,7 +388,12 @@ static int prv_send_next_msg(sMemfaultHttpContext *ctx) {
   memfault_http_start_chunk_post(prv_send_data, &sock, metadata.single_chunk_message_length);
 
   while (1) {
-    uint8_t buf[128];
+    // Allow somehow a larger buffer for more efficient transfers
+#if defined(CONFIG_MEMFAULT_HTTP_CHUNK_TRANSFER_BUFFER_SIZE)
+    uint8_t buf[CONFIG_MEMFAULT_HTTP_CHUNK_TRANSFER_BUFFER_SIZE];
+#else
+    uint8_t buf[1024];
+#endif
     size_t buf_len = sizeof(buf);
     eMemfaultPacketizerStatus status = memfault_packetizer_get_next(buf, &buf_len);
     if (status == kMemfaultPacketizerStatus_NoMoreData) {

--- a/ports/zephyr/common/memfault_platform_http.c
+++ b/ports/zephyr/common/memfault_platform_http.c
@@ -704,9 +704,8 @@ ssize_t memfault_zephyr_port_post_data_return_size(void) {
     rv = memfault_zephyr_port_http_upload_sdk_data(&ctx);
   }
 
-  if (rv == 0) {
-    memfault_zephyr_port_http_close_socket(&ctx);
-  }
+  // Always close the socket to prevent leaks
+  memfault_zephyr_port_http_close_socket(&ctx);
 
 #if defined(CONFIG_MEMFAULT_METRICS_SYNC_SUCCESS)
   if (rv == 0) {


### PR DESCRIPTION
Close sockets on failure to prevent leaks.
Additionally optimize buffer size on large uploads. 