### PR TITLE
ports: zephyr: ncs: make NFC reset reason conditional on nRF54 SoCs

### DIFF
--- a/ports/zephyr/ncs/src/nrfx_pmu_reboot_tracking.c
+++ b/ports/zephyr/ncs/src/nrfx_pmu_reboot_tracking.c
@@ -154,9 +154,11 @@ static eMemfaultRebootReason prv_decode_reset_resetreas(uint32_t reset_cause) {
   } else if (reset_cause & NRF_RESET_RESETREAS_DOG1_MASK) {
     MEMFAULT_PRINT_RESET_INFO(" Watchdog 1");
     reset_reason = kMfltRebootReason_HardwareWatchdog;
+  #if NRF_RESET_HAS_NFC_RESET
   } else if (reset_cause & NRF_RESET_RESETREAS_NFC_MASK) {
     MEMFAULT_PRINT_RESET_INFO(" NFC Wakeup");
     reset_reason = kMfltRebootReason_DeepSleep;
+  #endif
   } else if (reset_cause == 0) {
     // absence of a value, means a power on reset took place
     MEMFAULT_PRINT_RESET_INFO(" Power on Reset");


### PR DESCRIPTION
For SoCs where RESETREAS register in the RESET peripheral (nRF53, nRF54) add a preprocessor check if the NFC reset reason is available.