### PR TITLE
Fix log panic config

### DIFF
--- a/ports/zephyr/include/memfault/ports/zephyr/log_panic.h
+++ b/ports/zephyr/include/memfault/ports/zephyr/log_panic.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-#if defined(MEMFAULT_FAULT_HANDLER_LOG_PANIC)
+#if defined(CONFIG_MEMFAULT_FAULT_HANDLER_LOG_PANIC)
   #define MEMFAULT_LOG_PANIC() LOG_PANIC()
 #else
   #define MEMFAULT_LOG_PANIC()


### PR DESCRIPTION
The guard for `CONFIG_MEMFAULT_FAULT_HANDLER_LOG_PANIC` settting in `log_panic.h` was incorrectly used as `#if defined(MEMFAULT_FAULT_HANDLER_LOG_PANIC)`. 

Fixed it to refer to the correct config value: `CONFIG_MEMFAULT_FAULT_HANDLER_LOG_PANIC`.