### PR TITLE
Allow Zephyr's CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=-1

### DIFF
--- a/ports/zephyr/common/memfault_platform_http.c
+++ b/ports/zephyr/common/memfault_platform_http.c
@@ -94,7 +94,7 @@ sMfltHttpClientConfig g_mflt_http_client_config = {
 static char s_mflt_http_net_interface_name[IFNAMSIZ];
 #endif
 
-#if (CONFIG_MINIMAL_LIBC_MALLOC_ARENA_SIZE > 0)
+#if (CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE != 0)
 static void *prv_calloc(size_t count, size_t size) {
   return calloc(count, size);
 }
@@ -111,7 +111,7 @@ static void prv_free(void *ptr) {
   k_free(ptr);
 }
 #else
-  #error "CONFIG_MINIMAL_LIBC_MALLOC_ARENA_SIZE or CONFIG_HEAP_MEM_POOL_SIZE must be > 0"
+  #error "CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE or CONFIG_HEAP_MEM_POOL_SIZE must be > 0"
 #endif
 
 // Select either PEM or DER format to install to certificate storage.


### PR DESCRIPTION
When malloc() and free() are used in Zephyr, the
CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE may be defined as "-1" which means that all remaining RAM is used as a heap.