### PR TITLE
ports: zephyr: update renamed Mbed TLS Kconfig option

### DIFF
--- a/ports/zephyr/Kconfig
+++ b/ports/zephyr/Kconfig
@@ -494,7 +494,8 @@ choice MEMFAULT_TLS_CERTS_FORMAT
 
 config MEMFAULT_TLS_CERTS_USE_PEM
         bool "Use PEM format for TLS certificates"
-        depends on (MBEDTLS_PEM_CERTIFICATE_FORMAT || !(MBEDTLS && MBEDTLS_BUILTIN && MBEDTLS_CFG_FILE = "config-tls-generic.h"))
+        depends on (MBEDTLS_PEM_PARSE_C && MBEDTLS_PEM_WRITE_C) || \
+		   !(MBEDTLS && MBEDTLS_BUILTIN && MBEDTLS_CFG_FILE = "config-tls-generic.h")
         help
           When enabled, Memfault will use PEM format for TLS certificates.
           When disabled, DER format will be used.


### PR DESCRIPTION
`MBEDTLS_PEM_CERTIFICATE_FORMAT` was not a standard Mbed TLS configuration, and in Zephyr it has been replaced by what it used to enable under the hood: `MBEDTLS_PEM_PARSE_C` and `MBEDTLS_PEM_WRITE_C`