### PR TITLE
Enable panic print with MEMFAULT_FAULT_HANDLER_LOG_PANIC

### DIFF
--- a/ports/zephyr/include/memfault/ports/zephyr/log_panic.h
+++ b/ports/zephyr/include/memfault/ports/zephyr/log_panic.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-#if defined(MEMFAULT_FAULT_HANDLER_LOG_PANIC)
+#if defined(CONFIG_MEMFAULT_FAULT_HANDLER_LOG_PANIC)
   #define MEMFAULT_LOG_PANIC() LOG_PANIC()
 #else
   #define MEMFAULT_LOG_PANIC()


### PR DESCRIPTION
Fix missing CONFIG_ prefix in MEMFAULT_FAULT_HANDLER_LOG_PANIC usage.

Fixes #110 