### PR TITLE
fix: missing 'path' in Make example comment in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you are using `make`, `makefiles/MemfaultWorker.mk` can be used to very
 easily collect the source files and include paths required by the SDK.
 
 ```c
-MEMFAULT_SDK_ROOT := <The to the root of this repo from your project>
+MEMFAULT_SDK_ROOT := <The path to the root of this repo from your project>
 MEMFAULT_COMPONENTS := <The SDK components to be used, i.e "core util">
 include $(MEMFAULT_SDK_ROOT)/makefiles/MemfaultWorker.mk
 <YOUR_SRC_FILES> += $(MEMFAULT_COMPONENTS_SRCS)


### PR DESCRIPTION
## Summary
In the "Add sources to Build System" section under Make, the placeholder comment reads `<The to the root of this repo from your project>` — the word "path" is missing. The CMake section right below it correctly says `<The path to the root of the memfault-firmware-sdk repo>`. This fixes the Make example to match.

## How to reproduce
Open `README.md` and search for `MEMFAULT_SDK_ROOT :=`. The Make example has `<The to the root...>` while the CMake example has `<The path to the root...>`.

## Test plan
Confirm the README Make example now reads `MEMFAULT_SDK_ROOT := <The path to the root of this repo from your project>`.