### PR TITLE
ports/zephyr: include http_client.h for the settings project-key path

### DIFF
--- a/ports/zephyr/common/memfault_platform_project_key.c
+++ b/ports/zephyr/common/memfault_platform_project_key.c
@@ -13,7 +13,11 @@
 #include "memfault/core/compiler.h"
 #include "memfault/core/debug_log.h"
 
-#if defined(CONFIG_MEMFAULT_HTTP_CLIENT_CONFIG_BUILTIN)
+// http_client.h defines MEMFAULT_PROJECT_KEY_LEN, which the
+// CONFIG_MEMFAULT_PROJECT_KEY_SETTINGS path below also needs. Include it when
+// either that path or the built-in HTTP client config is enabled.
+#if defined(CONFIG_MEMFAULT_HTTP_CLIENT_CONFIG_BUILTIN) || \
+  defined(CONFIG_MEMFAULT_PROJECT_KEY_SETTINGS)
   #include "memfault/http/http_client.h"
 #endif
 


### PR DESCRIPTION
## Summary

`ports/zephyr/common/memfault_platform_project_key.c` uses `MEMFAULT_PROJECT_KEY_LEN`
under `CONFIG_MEMFAULT_PROJECT_KEY_SETTINGS` — to size `s_mflt_project_key` and in
`memfault_zephyr_port_set_project_key()` — but only includes the header that defines
that macro (`memfault/http/http_client.h`) under
`CONFIG_MEMFAULT_HTTP_CLIENT_CONFIG_BUILTIN`.

When `CONFIG_MEMFAULT_PROJECT_KEY_SETTINGS` is enabled *without*
`CONFIG_MEMFAULT_HTTP_CLIENT_CONFIG_BUILTIN`, the macro is undeclared and the build
fails:

```
error: 'MEMFAULT_PROJECT_KEY_LEN' undeclared here (not in a function)
   static char s_mflt_project_key[MEMFAULT_PROJECT_KEY_LEN + 1];
```

This combination occurs in the nRF Connect SDK, which disables
`CONFIG_MEMFAULT_HTTP_CLIENT_CONFIG_BUILTIN` (it defines `g_mflt_http_client_config`
itself) while allowing the settings-based project key.

## Change

Include `http_client.h` when either `CONFIG_MEMFAULT_HTTP_CLIENT_CONFIG_BUILTIN` or
`CONFIG_MEMFAULT_PROJECT_KEY_SETTINGS` is set, so the macro is in scope wherever the
file uses it. Header-only include; no behavioral change when HTTP is not enabled.

## Testing

Built and ran on an nRF54L15 DK via the nRF Connect SDK (memfault-firmware-sdk 1.42.0,
`CONFIG_MEMFAULT_PROJECT_KEY_SETTINGS=y`, `CONFIG_BT_MDS=y`, HTTP client config builtin
disabled):

- Build succeeds with this change (fails without it, with the error above).
- Serial `settings` contract for `memfault/project_key` passes: unset after flash,
  write/read round-trips, persists across a cold reboot, delete returns to unset.
