### PR TITLE
[nrf noup] zephyr: Use zephyr/ prefix for version.h includes

### DIFF
--- a/components/core/src/memfault_build_id.c
+++ b/components/core/src/memfault_build_id.c
@@ -27,7 +27,7 @@
     #else
       // This is Zephyr's version.h file, since Memfault's is namespaced as
       // "memfault/version.h".
-      #include <version.h>
+      #include <zephyr/version.h>
       #define MEMFAULT_OS_VERSION_NAME "zephyr"
       #define MEMFAULT_OS_VERSION_STRING KERNEL_VERSION_STRING
     #endif  // __has_include("ncs_version.h")

--- a/ports/zephyr/include/memfault/ports/zephyr/version.h
+++ b/ports/zephyr/include/memfault/ports/zephyr/version.h
@@ -12,7 +12,7 @@
 extern "C" {
 #endif
 
-#include <version.h>
+#include <zephyr/version.h>
 
 //! Returns true if current Zephyr Kernel Version is greater than the one specified
 //!


### PR DESCRIPTION
Upstream Zephyr disabled CONFIG_LEGACY_GENERATED_INCLUDE_PATH by default, so the kernel version header must be included as <zephyr/version.h>.