### PR TITLE
ports: zephyr: ncs: Allow building CoAP client without Modem

### DIFF
--- a/ports/zephyr/ncs/src/memfault_platform_coap.c
+++ b/ports/zephyr/ncs/src/memfault_platform_coap.c
@@ -18,10 +18,8 @@
 #include MEMFAULT_ZEPHYR_INCLUDE(random/random.h)
 
 #include <date_time.h>
-#include <modem/modem_jwt.h>
 #include <net/nrf_cloud_coap.h>
 #include <nrf_cloud_coap_transport.h>
-#include <nrf_modem_at.h>
 
 #include "memfault/components.h"
 #include "memfault/nrfconnect_port/coap.h"


### PR DESCRIPTION
Remove unused includes that were preventing the build on platforms without a modem.
The primary intention at the moment is to allow running from Wi-Fi boards.

Ticket: NCSDK-39782